### PR TITLE
Pulldown cmark feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,9 @@ categories = ["development-tools", "parsing"]
 travis-ci = { repository = "killercup/rust-docstrings", branch = "master" }
 
 [dependencies]
-pulldown-cmark = "0.0.14"
+# Optional because rustc ships it and one might want to use that one.
+pulldown-cmark = { version = "0.0.14", optional = true }
 quick-error = "1.1.0"
+
+[features]
+default = ["pulldown-cmark"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docstrings"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Pascal Hertleif <killercup@gmail.com>",
     "Martin Carton <cartonmartin@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 
 #![deny(missing_docs, warnings, unsafe_code, missing_debug_implementations)]
 
+#![cfg_attr(not(feature = "pulldown-cmark"), feature(rustc_private))]
+
 extern crate pulldown_cmark;
 #[macro_use] extern crate quick_error;
 


### PR DESCRIPTION
Make `pulldown-cmark` an optional dependency.
    
`rustc` currently ships `pulldown-cmark` and one might want to use this version of the crate rather than pulling it from crates.io.
    
This is required for Clippy, which uses the `rustc`'s crate.